### PR TITLE
amd_define option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,6 +66,18 @@ module.exports = function(grunt) {
           ],
         },
       },
+      amd_define_option: {
+        options: {
+          amd_define: 'my-templates',
+        },
+        files: {
+          'tmp/amd_define_option.js': [
+            'test/fixtures/greeting.twig',
+            'test/fixtures/weather.twig',
+            'test/fixtures/conditional.twig'
+          ],
+        },
+      },
       example1: {
         options: {},
         files: {

--- a/README.md
+++ b/README.md
@@ -52,9 +52,26 @@ Default value: `true`
 Determines whether the output will be wrapped in a `require(["twig"], ...)`
 call.
 
+#### options.amd_define
+Type: `boolean` or `string`  
+Default value: false         
+Requirement: `options.amd_wrapper` must be set to `true`
+
+Determines whether to define the AMD module or not.
+#### Examples
+* `options.amd_define: true` 
+    ```javascript 
+    define(["twig"], function(Twig) { ... return windows.JST; });
+    ``` 
+* `options.amd_define: 'my-templates'`
+    ```javascript 
+    define('my-templates', ["twig"], function(Twig) { ... return windows.JST; });
+    ``` 
+    (`windows.JST` may be replaced by `options.variable` value)
+
 #### options.variable
 Type: `string`  
-Default value: `'JST'`
+Default value: `'window.JST'`
 
 The name of the global variable that should store all the templates.
 

--- a/test/expected/amd_define_option.js
+++ b/test/expected/amd_define_option.js
@@ -1,0 +1,7 @@
+define("my-templates", ["twig"], function(Twig) {
+window.JST = window.JST || {};
+window.JST["test/fixtures/greeting.twig"] = Twig.twig({ data: [{"type":"raw","value":"Hello, "},{"type":"output","stack":[{"type":"Twig.expression.type.variable","value":"firstName","match":["firstName"]}]},{"type":"raw","value":" "},{"type":"output","stack":[{"type":"Twig.expression.type.variable","value":"lastName","match":["lastName"]}]},{"type":"raw","value":"!\n"}] });
+window.JST["test/fixtures/weather.twig"] = Twig.twig({ data: [{"type":"raw","value":"The weather today is "},{"type":"output","stack":[{"type":"Twig.expression.type.variable","value":"weather","match":["weather"]}]},{"type":"raw","value":".\n"}] });
+window.JST["test/fixtures/conditional.twig"] = Twig.twig({ data: [{"type":"logic","token":{"type":"Twig.logic.type.if","stack":[{"type":"Twig.expression.type.variable","value":"value","match":["value"]}],"output":[{"type":"raw","value":"  "},{"type":"output","stack":[{"type":"Twig.expression.type.variable","value":"value","match":["value"]}]},{"type":"raw","value":"\n"}]}},{"type":"logic","token":{"type":"Twig.logic.type.else","match":["else"],"output":[{"type":"raw","value":"  No value\n"}]}}] });
+return window.JST;
+});

--- a/test/expected/variable_option.js
+++ b/test/expected/variable_option.js
@@ -1,5 +1,5 @@
 require(["twig"], function(Twig) {
-myTemplates = myTemplates || {};
+var myTemplates = myTemplates || {};
 myTemplates["test/fixtures/conditional.twig"] = Twig.twig({ data: [{"type":"logic","token":{"type":"Twig.logic.type.if","stack":[{"type":"Twig.expression.type.variable","value":"value","match":["value"]}],"output":[{"type":"raw","value":"  "},{"type":"output","stack":[{"type":"Twig.expression.type.variable","value":"value","match":["value"]}]},{"type":"raw","value":"\n"}]}},{"type":"logic","token":{"type":"Twig.logic.type.else","match":["else"],"output":[{"type":"raw","value":"  No value\n"}]}}] });
 myTemplates["test/fixtures/greeting.twig"] = Twig.twig({ data: [{"type":"raw","value":"Hello, "},{"type":"output","stack":[{"type":"Twig.expression.type.variable","value":"firstName","match":["firstName"]}]},{"type":"raw","value":" "},{"type":"output","stack":[{"type":"Twig.expression.type.variable","value":"lastName","match":["lastName"]}]},{"type":"raw","value":"!\n"}] });
 myTemplates["test/fixtures/weather.twig"] = Twig.twig({ data: [{"type":"raw","value":"The weather today is "},{"type":"output","stack":[{"type":"Twig.expression.type.variable","value":"weather","match":["weather"]}]},{"type":"raw","value":".\n"}] });

--- a/test/twig_test.js
+++ b/test/twig_test.js
@@ -30,7 +30,8 @@ exports.twig = {
     var names = [
       'default_options',
       'variable_option',
-      'template_key_option'
+      'template_key_option',
+      'amd_define_option'
     ];
 
     test.expect(names.length);


### PR DESCRIPTION
Added amd_define option (+test).
Updated Readme (options.variable default value).
Fix #4 issue (missing var keyword).
Fix tests on Windows (don't normalize linefeeds).